### PR TITLE
pull request NUFFT

### DIFF
--- a/benchmarking/lofar_nufft.py
+++ b/benchmarking/lofar_nufft.py
@@ -26,7 +26,6 @@ warnings.filterwarnings('ignore', category=UserWarning, append=True)
 warnings.simplefilter('ignore', category=AstropyWarning)
 
 t = Timer()
-xp = bbt_cupy.cupy if use_cupy else np
 
 time_slice = 100
 N_station = 24

--- a/benchmarking/lofar_nufft.py
+++ b/benchmarking/lofar_nufft.py
@@ -29,7 +29,7 @@ t = Timer()
 xp = bbt_cupy.cupy if use_cupy else np
 
 time_slice = 100
-N_station = 60
+N_station = 24
 N_level = 4
 
 fname_prefix = 'lofar30MHz1'

--- a/benchmarking/lofar_nufft.py
+++ b/benchmarking/lofar_nufft.py
@@ -5,6 +5,9 @@
 # Simulated LOFAR imaging with Bluebild (NUFFT).
 # #############################################################################
 
+import bluebild_tools.cupy_util as bbt_cupy
+use_cupy = bbt_cupy.is_cupy_usable()
+
 from tqdm import tqdm as ProgressBar
 import astropy.units as u
 from imot_tools.io import fits as ifits, s2image

--- a/benchmarking/lofar_nufft.py
+++ b/benchmarking/lofar_nufft.py
@@ -12,7 +12,6 @@ from tqdm import tqdm as ProgressBar
 import astropy.units as u
 from imot_tools.io import fits as ifits, s2image
 import numpy as np
-import cupy as cp
 import scipy.constants as constants
 
 from pypeline.phased_array.bluebild import data_processor as bb_dp, gram as bb_gr
@@ -27,6 +26,7 @@ warnings.filterwarnings('ignore', category=UserWarning, append=True)
 warnings.simplefilter('ignore', category=AstropyWarning)
 
 t = Timer()
+xp = bbt_cupy.cupy if use_cupy else np
 
 time_slice = 100
 N_station = 60

--- a/benchmarking/lofar_nufft.py
+++ b/benchmarking/lofar_nufft.py
@@ -28,7 +28,6 @@ warnings.simplefilter('ignore', category=AstropyWarning)
 
 t = Timer()
 
-gpu = True
 time_slice = 100
 N_station = 60
 N_level = 4
@@ -166,11 +165,6 @@ for i_t, ti in enumerate(ProgressBar(time)):
     W = ms.beamformer(XYZ, wl)
     G = gram(XYZ, W, wl)
     D, V = S_dp(G)
-
-    if(gpu):
-        XYZ_gpu = cp.asarray(XYZ.data)
-        W_gpu  = cp.asarray(W.data.toarray())
-        V_gpu  = cp.asarray(V)
 
     S_sensitivity = SV_dp(D, V, W, cluster_idx=np.zeros(N_eig, dtype=int))  # (W @ ((V @ np.diag(D)) @ V.transpose().conj())) @ W.transpose().conj()
     sensitivity_coeffs.append(S_sensitivity)

--- a/benchmarking/lofar_nufft.py
+++ b/benchmarking/lofar_nufft.py
@@ -1,0 +1,193 @@
+# #############################################################################
+# lofar_nufft.py
+# ==================
+# Author : Sepand KASHANI [kashani.sepand@gmail.com] (modified by Michele)
+# Simulated LOFAR imaging with Bluebild (NUFFT).
+# #############################################################################
+
+from tqdm import tqdm as ProgressBar
+import astropy.units as u
+from imot_tools.io import fits as ifits, s2image
+import numpy as np
+import cupy as cp
+import scipy.constants as constants
+
+from pypeline.phased_array.bluebild import data_processor as bb_dp, gram as bb_gr
+from pypeline.phased_array.bluebild.imager import spatial_domain as bb_sd, fourier_domain as bb_im
+from timing import Timer
+
+from pypeline.phased_array import measurement_set
+
+import warnings
+from astropy.utils.exceptions import AstropyWarning
+warnings.filterwarnings('ignore', category=UserWarning, append=True)
+warnings.simplefilter('ignore', category=AstropyWarning)
+
+t = Timer()
+
+gpu = True
+time_slice = 100
+N_station = 60
+N_level = 4
+
+fname_prefix = 'lofar30MHz1'
+path_out = './'
+path_in = '/project/c31/%s/' %fname_prefix
+fname = '%s_t201806301100_SBL153.MS' %(path_in+fname_prefix)
+data_column="MODEL_DATA"
+
+t.start_time("Set up data")
+# Measurement Set
+ms = measurement_set.LofarMeasurementSet(fname, N_station)
+channel_id = 1
+frequency = ms.channels["FREQUENCY"][channel_id]
+wl = constants.speed_of_light / frequency.to_value(u.Hz)
+
+# Observation
+FoV = np.deg2rad((2000*2.*u.arcsec).to(u.deg).value)
+field_center = ms.field_center
+time = ms.time['TIME'][:time_slice]
+
+# Instrument
+gram = bb_gr.GramBlock()
+
+# Imaging
+eps = 1e-3
+w_term = True
+precision = 'single'
+N_bits = 32
+
+### NUFFT imaging parameters ===========================================================
+cl_WCS = ifits.wcs('%s%s-psf.fits' %(path_in, fname_prefix))
+cl_WCS = cl_WCS.sub(['celestial']) 
+#cl_WCS = cl_WCS.slice((slice(None, None, 10), slice(None, None, 10)))  # downsample, too high res!
+px_grid = ifits.pix_grid(cl_WCS)  # (3, N_cl_lon, N_cl_lat) ICRS reference frame
+N_cl_lon, N_cl_lat = px_grid.shape[-2:]
+assert N_cl_lon == N_cl_lat
+N_pix = N_cl_lon
+
+t.end_time("Set up data")
+print('''You are running bluebild on file: %s
+         with the following input parameters:
+         %d timesteps
+         %d stations
+         clustering into %d levels
+         The output grid will be %dx%d = %d pixels''' %(fname, len(time), N_station, N_level, px_grid.shape[1],  px_grid.shape[2],  px_grid.shape[1]* px_grid.shape[2]))
+
+### Intensity Field =================================================
+# Parameter Estimation
+
+t.start_time("Estimate intensity field parameters")
+"""
+I_est = bb_pe.IntensityFieldParameterEstimator(N_level, sigma=0.95)
+for i_t, ti in enumerate(ProgressBar(time)):
+    tobs, f, S = next(data.ms.visibilities(channel_id=[data.channel_id], time_id=slice(i_t, i_t+1, None), column=data_column))
+    wl = constants.speed_of_light / f.to_value(u.Hz) #self.wl
+    XYZ = ms.instrument(tobs)
+    W = ms.beamformer(XYZ, wl)
+    S, _ = measurement_set.filter_data(S, W)
+    
+    G = gram(XYZ, W, wl)
+
+    I_est.collect(S, G)
+N_eig, c_centroid = I_est.infer_parameters()
+print(N_eig, c_centroid)
+"""
+N_eig, c_centroid = N_level, list(range(N_level))        # bypass centroids
+t.end_time("Estimate intensity field parameters")
+
+####################################################################
+#### Imaging
+####################################################################
+I_dp = bb_dp.IntensityFieldDataProcessorBlock(N_eig, c_centroid)
+IV_dp = bb_dp.VirtualVisibilitiesDataProcessingBlock(N_eig, filters=('lsq','sqrt'))
+
+I_mfs_ss = bb_sd.Spatial_IMFS_Block(wl, px_grid, N_level, N_bits)
+
+UVW_baselines = []
+gram_corrected_visibilities = []
+for i_t, ti in enumerate(ProgressBar(time)):
+    t.start_time("Synthesis: prep input matrices & fPCA")
+    tobs, f, S = next(ms.visibilities(channel_id=[channel_id], time_id=slice(i_t, i_t+1, None), column=data_column))
+    wl = constants.speed_of_light / f.to_value(u.Hz)
+    XYZ = ms.instrument(tobs)
+    W = ms.beamformer(XYZ, wl)
+    S, _ = measurement_set.filter_data(S, W)
+
+    G = gram(XYZ, W, wl)
+    D, V, c_idx = I_dp(S, G)
+    c_idx = list(range(N_level))        # bypass c_idx
+    t.end_time("Synthesis: prep input matrices & fPCA")
+    
+    t.start_time("NUFFT Synthesis")
+    UVW_baselines_t = ms.instrument.baselines(ti, uvw=True, field_center=field_center)
+    UVW_baselines.append(UVW_baselines_t)
+    S_corrected = IV_dp(D, V, W, c_idx)
+    gram_corrected_visibilities.append(S_corrected)
+    t.end_time("NUFFT Synthesis")
+
+UVW_baselines = np.stack(UVW_baselines, axis=0).reshape(-1, 3)
+gram_corrected_visibilities = np.stack(gram_corrected_visibilities, axis=-3).reshape(*S_corrected.shape[:2], -1)
+
+# NUFFT Synthesis
+nufft_imager = bb_im.NUFFT_IMFS_Block(wl=wl, UVW=UVW_baselines.T, grid_size=px_grid, FoV=FoV, field_center=field_center, eps=eps, w_term=w_term, n_trans=np.prod(gram_corrected_visibilities.shape[:-1]), precision=precision)
+#nufft_imager = bb_im.NUFFT_IMFS_Block(wl=wl, UVW=UVW_baselines.T, grid_size=N_pix, FoV=FoV, field_center=field_center, eps=eps, w_term=w_term, n_trans=np.prod(gram_corrected_visibilities.shape[:-1]), precision=precision)
+lsq_image, sqrt_image = nufft_imager(gram_corrected_visibilities)
+#============================================================================================
+
+### Sensitivity Field =========================================================
+t.start_time("Estimate sensitivity field parameters")
+"""
+# Parameter Estimation
+S_est = bb_pe.SensitivityFieldParameterEstimator(sigma=0.95)
+for ti in ProgressBar(time):
+    XYZ = ms.instrument(ti)
+    W = ms.beamformer(XYZ, wl)
+    G = gram(XYZ, W, wl)
+    S_est.collect(G)
+N_eig, c_centroid = I_est.infer_parameters()
+"""
+N_eig, c_centroid = N_level, list(range(N_level))
+t.end_time("Estimate sensitivity field parameters")
+
+# Imaging
+S_dp = bb_dp.SensitivityFieldDataProcessorBlock(N_eig)
+SV_dp = bb_dp.VirtualVisibilitiesDataProcessingBlock(N_eig, filters=('lsq',))
+sensitivity_coeffs = []
+
+for i_t, ti in enumerate(ProgressBar(time)):
+    tobs, f, S = next(ms.visibilities(channel_id=[channel_id], time_id=slice(i_t, i_t+1, None), column=data_column))
+    wl = constants.speed_of_light / f.to_value(u.Hz)
+    XYZ = ms.instrument(tobs)
+
+    W = ms.beamformer(XYZ, wl)
+    G = gram(XYZ, W, wl)
+    D, V = S_dp(G)
+
+    if(gpu):
+        XYZ_gpu = cp.asarray(XYZ.data)
+        W_gpu  = cp.asarray(W.data.toarray())
+        V_gpu  = cp.asarray(V)
+
+    S_sensitivity = SV_dp(D, V, W, cluster_idx=np.zeros(N_eig, dtype=int))  # (W @ ((V @ np.diag(D)) @ V.transpose().conj())) @ W.transpose().conj()
+    sensitivity_coeffs.append(S_sensitivity)
+
+np.save('%sD_%s' %(path_out, fname_prefix), D.reshape(-1, 1, 1))
+
+sensitivity_coeffs = np.stack(sensitivity_coeffs, axis=0).reshape(-1)
+nufft_imager = bb_im.NUFFT_IMFS_Block(wl=wl, UVW=UVW_baselines.T, grid_size=N_pix, FoV=FoV,
+                                      field_center=field_center, eps=eps, w_term=w_term,
+                                      n_trans=1, precision=precision)
+sensitivity_image = nufft_imager(sensitivity_coeffs)
+
+#I_sqrt_eq_nufft = s2image.Image(sqrt_image / sensitivity_image, nufft_imager._synthesizer.xyz_grid)
+I_lsq_eq_nufft = s2image.Image(lsq_image / sensitivity_image, nufft_imager._synthesizer.xyz_grid)
+
+# Save eigen-vectors for NUFFT
+#np.save('%sI_lsq_eq_nufft_Nsrc%d_Nlvl%d' %(path_out, N_src, N_level), I_lsq_eq_nufft.data)
+np.save('%sI_nufft_%s' %(path_out, fname_prefix), I_lsq_eq_nufft.data)
+
+# Interpolate image to MS grid-frame for NUFFT
+f_interp = (I_lsq_eq_nufft.data.reshape(N_level, N_cl_lon, N_cl_lat).transpose(0, 2, 1))
+I_lsq_eq_interp = s2image.WCSImage(f_interp, cl_WCS)
+I_lsq_eq_interp.to_fits('%sI_nufft_%s.fits' %(path_out, fname_prefix))

--- a/benchmarking/lofar_ss.py
+++ b/benchmarking/lofar_ss.py
@@ -12,7 +12,6 @@ from tqdm import tqdm as ProgressBar
 import astropy.units as u
 from imot_tools.io import fits as ifits, s2image
 import numpy as np
-import cupy as cp
 import scipy.constants as constants
 
 from pypeline.phased_array.bluebild import gram as bb_gr, data_processor as bb_dp, parameter_estimator as bb_pe
@@ -27,6 +26,7 @@ warnings.filterwarnings('ignore', category=UserWarning, append=True)
 warnings.simplefilter('ignore', category=AstropyWarning)
 
 t = Timer()
+xp = bbt_cupy.cupy if use_cupy else np
 
 time_slice = 100
 N_station = 60
@@ -118,9 +118,9 @@ for i_t, ti in enumerate(ProgressBar(time)):
     
     t.start_time("Standard Synthesis")
     if(use_cupy):
-        XYZ_gpu = cp.asarray(XYZ.data)
-        W_gpu  = cp.asarray(W.data.toarray())
-        V_gpu  = cp.asarray(V)
+        XYZ_gpu = xp.asarray(XYZ.data)
+        W_gpu  = xp.asarray(W.data)
+        V_gpu  = xp.asarray(V)
         _ = I_mfs_ss(D, V_gpu, XYZ_gpu, W_gpu, c_idx)
     else:
         _ = I_mfs_ss(D, V, XYZ.data, W.data, c_idx)
@@ -160,9 +160,9 @@ for i_t, ti in enumerate(ProgressBar(time)):
     D, V = S_dp(G)
 
     if(use_cupy):
-        XYZ_gpu = cp.asarray(XYZ.data)
-        W_gpu  = cp.asarray(W.data.toarray())
-        V_gpu  = cp.asarray(V)
+        XYZ_gpu = xp.asarray(XYZ.data)
+        W_gpu  = xp.asarray(W.data)
+        V_gpu  = xp.asarray(V)
         _ = S_mfs_ss(D, V_gpu, XYZ_gpu, W_gpu, cluster_idx=np.zeros(N_eig, dtype=int))
     else:
         _ = S_mfs_ss(D, V, XYZ, W, cluster_idx=np.zeros(N_eig, dtype=int))

--- a/benchmarking/lofar_ss.py
+++ b/benchmarking/lofar_ss.py
@@ -5,6 +5,9 @@
 # Simulated LOFAR imaging with Bluebild (Standard).
 # #############################################################################
 
+import bluebild_tools.cupy_util as bbt_cupy
+use_cupy = bbt_cupy.is_cupy_usable()
+
 from tqdm import tqdm as ProgressBar
 import astropy.units as u
 from imot_tools.io import fits as ifits, s2image

--- a/benchmarking/lofar_ss.py
+++ b/benchmarking/lofar_ss.py
@@ -28,7 +28,6 @@ warnings.simplefilter('ignore', category=AstropyWarning)
 
 t = Timer()
 
-gpu = True
 time_slice = 100
 N_station = 60
 N_level = 4
@@ -118,7 +117,7 @@ for i_t, ti in enumerate(ProgressBar(time)):
     t.end_time("Synthesis: prep input matrices & fPCA")
     
     t.start_time("Standard Synthesis")
-    if(gpu):
+    if(use_cupy):
         XYZ_gpu = cp.asarray(XYZ.data)
         W_gpu  = cp.asarray(W.data.toarray())
         V_gpu  = cp.asarray(V)
@@ -160,7 +159,7 @@ for i_t, ti in enumerate(ProgressBar(time)):
     G = gram(XYZ, W, wl)
     D, V = S_dp(G)
 
-    if(gpu):
+    if(use_cupy):
         XYZ_gpu = cp.asarray(XYZ.data)
         W_gpu  = cp.asarray(W.data.toarray())
         V_gpu  = cp.asarray(V)

--- a/benchmarking/lofar_ss.py
+++ b/benchmarking/lofar_ss.py
@@ -1,0 +1,184 @@
+# #############################################################################
+# lofar_ss.py
+# ==================
+# Author : Sepand KASHANI [kashani.sepand@gmail.com] (modified by Michele)
+# Simulated LOFAR imaging with Bluebild (Standard).
+# #############################################################################
+
+from tqdm import tqdm as ProgressBar
+import astropy.units as u
+from imot_tools.io import fits as ifits, s2image
+import numpy as np
+import cupy as cp
+import scipy.constants as constants
+
+from pypeline.phased_array.bluebild import gram as bb_gr, data_processor as bb_dp, parameter_estimator as bb_pe
+from pypeline.phased_array.bluebild.imager import spatial_domain as bb_sd
+from timing import Timer
+
+from pypeline.phased_array import measurement_set
+
+import warnings
+from astropy.utils.exceptions import AstropyWarning
+warnings.filterwarnings('ignore', category=UserWarning, append=True)
+warnings.simplefilter('ignore', category=AstropyWarning)
+
+t = Timer()
+
+gpu = True
+time_slice = 100
+N_station = 60
+N_level = 4
+
+fname_prefix = 'lofar30MHz1'
+path_out = './'
+path_in = '/project/c31/%s/' %fname_prefix
+fname = '%s_t201806301100_SBL153.MS' %(path_in+fname_prefix)
+data_column="MODEL_DATA"
+
+t.start_time("Set up data")
+# Measurement Set
+ms = measurement_set.LofarMeasurementSet(fname, N_station)
+channel_id = 1
+frequency = ms.channels["FREQUENCY"][channel_id]
+wl = constants.speed_of_light / frequency.to_value(u.Hz)
+
+# Observation
+FoV = np.deg2rad((2000*2.*u.arcsec).to(u.deg).value)
+field_center = ms.field_center
+time = ms.time['TIME'][:time_slice]
+
+# Instrument
+gram = bb_gr.GramBlock()
+
+# Imaging
+eps = 1e-3
+precision = 'single'
+N_bits = 32
+
+### Imaging parameters ===========================================================
+cl_WCS = ifits.wcs('%s-image.fits' %(path_in+fname_prefix))
+cl_WCS = cl_WCS.sub(['celestial']) 
+#cl_WCS = cl_WCS.slice((slice(None, None, 10), slice(None, None, 10)))  # downsample, too high res!
+px_grid = ifits.pix_grid(cl_WCS)  # (3, N_cl_lon, N_cl_lat) ICRS reference frame
+N_cl_lon, N_cl_lat = px_grid.shape[-2:]
+assert N_cl_lon == N_cl_lat
+N_pix = N_cl_lon
+
+t.end_time("Set up data")
+print('''You are running bluebild on file: %s
+         with the following input parameters:
+         %d timesteps
+         %d stations
+         clustering into %d levels
+         The output grid will be %dx%d = %d pixels''' %(fname, len(time), N_station, N_level, px_grid.shape[1],  px_grid.shape[2],  px_grid.shape[1]* px_grid.shape[2]))
+
+### Intensity Field =================================================
+# Parameter Estimation
+t.start_time("Estimate intensity field parameters")
+"""
+I_est = bb_pe.IntensityFieldParameterEstimator(N_level, sigma=0.95)
+for i_t, ti in enumerate(ProgressBar(time)):
+    tobs, f, S = next(ms.visibilities(channel_id=[channel_id], time_id=slice(i_t, i_t+1, None), column=data_column))
+    wl = constants.speed_of_light / f.to_value(u.Hz) #self.wl
+    XYZ = ms.instrument(tobs)
+    W = ms.beamformer(XYZ, wl)
+    S, _ = measurement_set.filter_data(S, W)
+    
+    G = gram(XYZ, W, wl)
+    I_est.collect(S, G)
+N_eig, c_centroid = I_est.infer_parameters()
+print(N_eig, c_centroid)
+"""
+N_eig, c_centroid = N_level, list(range(N_level))        # bypass centroids
+t.end_time("Estimate intensity field parameters")
+
+####################################################################
+#### Imaging
+####################################################################
+I_dp = bb_dp.IntensityFieldDataProcessorBlock(N_eig, c_centroid)
+I_mfs_ss = bb_sd.Spatial_IMFS_Block(wl, px_grid, N_level, N_bits)
+
+UVW_baselines = []
+for i_t, ti in enumerate(ProgressBar(time)):
+    t.start_time("Synthesis: prep input matrices & fPCA")
+
+    tobs, f, S = next(ms.visibilities(channel_id=[channel_id], time_id=slice(i_t, i_t+1, None), column=data_column))
+    wl = constants.speed_of_light / f.to_value(u.Hz)
+    XYZ = ms.instrument(tobs)
+    W = ms.beamformer(XYZ, wl)
+    S, _ = measurement_set.filter_data(S, W)
+    
+    G = gram(XYZ, W, wl)
+    D, V, c_idx = I_dp(S, G)
+    c_idx = list(range(N_level))        # bypass c_idx
+    t.end_time("Synthesis: prep input matrices & fPCA")
+    
+    t.start_time("Standard Synthesis")
+    if(gpu):
+        XYZ_gpu = cp.asarray(XYZ.data)
+        W_gpu  = cp.asarray(W.data.toarray())
+        V_gpu  = cp.asarray(V)
+        _ = I_mfs_ss(D, V_gpu, XYZ_gpu, W_gpu, c_idx)
+    else:
+        _ = I_mfs_ss(D, V, XYZ.data, W.data, c_idx)
+
+    t.end_time("Standard Synthesis")
+
+I_std_ss, I_lsq_ss = I_mfs_ss.as_image()
+
+#============================================================================================
+
+### Sensitivity Field =========================================================
+t.start_time("Estimate sensitivity field parameters")
+"""
+# Parameter Estimation
+S_est = bb_pe.SensitivityFieldParameterEstimator(sigma=0.95)
+for ti in ProgressBar(time):
+    XYZ = ms.instrument(ti)
+    W = ms.beamformer(XYZ, wl)
+    G = gram(XYZ, W, wl)
+    S_est.collect(G)
+N_eig, c_centroid = I_est.infer_parameters()
+"""
+N_eig, c_centroid = N_level, list(range(N_level))
+t.end_time("Estimate sensitivity field parameters")
+
+# Imaging
+S_dp = bb_dp.SensitivityFieldDataProcessorBlock(N_eig)
+S_mfs_ss = bb_sd.Spatial_IMFS_Block(wl, px_grid, 1, N_bits)
+
+for i_t, ti in enumerate(ProgressBar(time)):
+    tobs, f, S = next(ms.visibilities(channel_id=[channel_id], time_id=slice(i_t, i_t+1, None), column=data_column))
+    wl = constants.speed_of_light / f.to_value(u.Hz)
+    XYZ = ms.instrument(tobs)
+    
+    W = ms.beamformer(XYZ, wl)
+    G = gram(XYZ, W, wl)
+    D, V = S_dp(G)
+
+    if(gpu):
+        XYZ_gpu = cp.asarray(XYZ.data)
+        W_gpu  = cp.asarray(W.data.toarray())
+        V_gpu  = cp.asarray(V)
+        _ = S_mfs_ss(D, V_gpu, XYZ_gpu, W_gpu, cluster_idx=np.zeros(N_eig, dtype=int))
+    else:
+        _ = S_mfs_ss(D, V, XYZ, W, cluster_idx=np.zeros(N_eig, dtype=int))
+
+
+# Save eigen-values
+np.save('%sD_%s' %(path_out, fname_prefix), D.reshape(-1, 1, 1))
+
+_, S_ss = S_mfs_ss.as_image()
+
+# Image Gridding
+I_lsq_eq_ss = s2image.Image(I_lsq_ss.data / S_ss.data, I_lsq_ss.grid)
+
+# Save eigen-vectors for Standard Synthesis
+np.save('%sI_ss_%s' %(path_out, fname_prefix), I_lsq_eq_ss.data)
+
+# Interpolate image to MS grid-frame for Standard Synthesis
+f_interp = (I_lsq_eq_ss.data.reshape(N_level, N_cl_lon, N_cl_lat).transpose(0, 2, 1))
+I_lsq_eq_interp = s2image.WCSImage(f_interp, cl_WCS)
+I_lsq_eq_interp.to_fits('%sI_ss_%s.fits' %(path_out, fname_prefix))
+

--- a/pypeline/phased_array/bluebild/field_synthesizer/fourier_domain.py
+++ b/pypeline/phased_array/bluebild/field_synthesizer/fourier_domain.py
@@ -508,10 +508,16 @@ class NUFFTFieldSynthesizerBlock(synth.FieldSynthesizerBlock):
         self._precision = precision
         UVW = np.array(UVW, copy=False)
         self._UVW = (2 * np.pi * UVW.reshape(3, -1) / wl).astype(self._precision_mappings[self._precision]['real'])
-        self._grid_size = grid_size
         self._FoV = FoV
         self._field_center = field_center
-        self.lmn_grid, self.xyz_grid = self._make_grids()
+        if(w_term and type(grid_size) != int):
+            uvw_frame = frame.uvw_basis(self._field_center)
+            self.xyz_grid = grid_size       # pass a grid instead of calculating it
+            self.lmn_grid = np.tensordot(np.linalg.inv(uvw_frame), self.xyz_grid, axes=1)
+        else:
+            self._grid_size = grid_size
+            self.lmn_grid, self.xyz_grid = self._make_grids()
+
         self._lmn_grid = self.lmn_grid.reshape(3, -1).astype(self._precision_mappings[self._precision]['real'])
         self._n_trans = n_trans
         if w_term:


### PR DESCRIPTION
created two separate scripts in benchmarking/ for calculating SS and NUFFT on LOFAR LoSiTo mock data, namely lofar_nufft.py and lofar_ss.py. Moreover, modified fourier_domain.py so that you can pass a pre-defined grid (e.g: WSCLEAN) instead of calculating one for the NUFFT case.