### PR TITLE
Split NUFFT and better integration of the C++ library

### DIFF
--- a/benchmarking/data_gen_utils.py
+++ b/benchmarking/data_gen_utils.py
@@ -144,8 +144,7 @@ class SimulatedDataGen():
         XYZ = self.dev(t)
         W = self.mb(XYZ, self.wl)
         S = self.vis(XYZ, W, self.wl)
-        G = self.gram(XYZ, W, self.wl)
-        D, V, __ = self.I_dp(S, G)
+        D, V, __ = self.I_dp(S, XYZ, W, self.wl)
         return (V,XYZ.data, W.data, D)
 
 #################################################################################
@@ -218,12 +217,10 @@ class RealDataGen():
             XYZ = self.ms.instrument(t)
         with nvtx.annotate("getVXYZWD W", color="silver"):
             W = self.ms.beamformer(XYZ, self.wl)
-        with nvtx.annotate("getVXYZWD G", color="cyan"):
-            G = self.gram(XYZ, W, self.wl)
         with nvtx.annotate("getVXYZWD S", color="grey"):
             S, _ = measurement_set.filter_data(S, W)
         with nvtx.annotate("getVXYZWD I_dp", color="orange"):
-            D, V, c_idx = self.I_dp(S, G)
+            D, V, c_idx = self.I_dp(S, XYZ, W, self.wl)
 
         return (V, XYZ.data, W.data,D)
 
@@ -233,9 +230,8 @@ class RealDataGen():
         wl = constants.speed_of_light / f.to_value(u.Hz) #self.wl
         XYZ = self.ms.instrument(t)
         W = self.ms.beamformer(XYZ, wl)
-        G = self.gram(XYZ, W, wl)
         S, _ = measurement_set.filter_data(S, W)
-        D, V, c_idx = self.I_dp(S, G)
-        Ds, Vs = self.S_dp(G)
+        D, V, c_idx = self.I_dp(S, XYZ, W, wl)
+        Ds, Vs = self.S_dp(XYZ, W, wl)
 
         return (V, Vs, XYZ.data, W.data,D, Ds)

--- a/benchmarking/lofar_bootes_ps.py
+++ b/benchmarking/lofar_bootes_ps.py
@@ -115,11 +115,10 @@ for t in ProgressBar(imaging_timesteps):
     XYZ = dev(t)
     W = mb(XYZ, wl)
     S = vis(XYZ, W, wl)
-    G = gram(XYZ, W, wl)
     t_ifi_iteration_data += stime.process_time() - t_ifi_start
 
     t = stime.process_time()
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     t_ifi_iteration_dp += stime.process_time() - t
 
     t = stime.process_time()
@@ -158,11 +157,10 @@ for t in ProgressBar(imaging_timesteps):
     t_sfi_start = stime.process_time()
     XYZ = dev(t)
     W = mb(XYZ, wl)
-    G = gram(XYZ, W, wl)
     t_sfi_iteration_data += stime.process_time() - t_sfi_start
 
     t = stime.process_time()
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     t_sfi_iteration_dp += stime.process_time() - t
 
     t = stime.process_time()

--- a/benchmarking/lofar_bootes_ss.py
+++ b/benchmarking/lofar_bootes_ss.py
@@ -103,9 +103,8 @@ for t in ProgressBar(imaging_timesteps):
     XYZ = dev(t)
     W = mb(XYZ, wl)
     S = vis(XYZ, W, wl)
-    G = gram(XYZ, W, wl)
 
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
 
     timer.start_time("Intensity field imager call")
     __  = I_mfs(D, V, XYZ.data, W.data, c_idx)

--- a/benchmarking/lofar_ss.py
+++ b/benchmarking/lofar_ss.py
@@ -111,8 +111,7 @@ for i_t, ti in enumerate(ProgressBar(time)):
     W = ms.beamformer(XYZ, wl)
     S, _ = measurement_set.filter_data(S, W)
     
-    G = gram(XYZ, W, wl)
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     c_idx = list(range(N_level))        # bypass c_idx
     t.end_time("Synthesis: prep input matrices & fPCA")
     
@@ -156,8 +155,7 @@ for i_t, ti in enumerate(ProgressBar(time)):
     XYZ = ms.instrument(tobs)
     
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
 
     if(use_cupy):
         XYZ_gpu = xp.asarray(XYZ.data)

--- a/benchmarking/test_bluebild.py
+++ b/benchmarking/test_bluebild.py
@@ -157,9 +157,8 @@ for ti in ProgressBar(time[timeslice]):
     XYZ = dev(ti)
     W = mb(XYZ, wl)
     S = vis(XYZ, W, wl)
-    G = gram(XYZ, W, wl)
 
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     t.end_time("Synthesis: prep input matrices & fPCA")
 
     t.start_time("Periodic Synthesis")
@@ -237,9 +236,8 @@ for ti in ProgressBar(time[timeslice]):
 
     XYZ = dev(ti)
     W = mb(XYZ, wl)
-    G = gram(XYZ, W, wl)
 
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     W = W.data
 
     _ = S_mfs_ps(D, V, XYZ.data, W, cluster_idx=np.zeros(N_eig, dtype=int))

--- a/benchmarking/test_nufft_ss_sizing.py
+++ b/benchmarking/test_nufft_ss_sizing.py
@@ -159,12 +159,10 @@ for ti in ProgressBar(time[timeslice]):
     XYZ = dev(ti)
     W   = mb(XYZ, wl)
     S   = vis(XYZ, W, wl)
-    G   = gram(XYZ, W, wl)
     print("Matrix XYZ dimensions:", XYZ.shape)
     print("Matrix W dimensions:", W.shape)
-    print("Matrix G dimensions:", G.shape)
     print("Matrix S dimensions:", S.shape)
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     print("Matrix V dimensions:", V.shape)
     print("Matrix D dimensions:", D.shape)
     t.end_time("Synthesis: prep input matrices & fPCA")
@@ -260,9 +258,8 @@ for ti in ProgressBar(time[timeslice]):
 
     XYZ = dev(ti)
     W = mb(XYZ, wl)
-    G = gram(XYZ, W, wl)
 
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     W = W.data
 
     #_ = S_mfs_ps(D, V, XYZ.data, W, cluster_idx=np.zeros(N_eig, dtype=int))

--- a/benchmarking/test_synthesizer.py
+++ b/benchmarking/test_synthesizer.py
@@ -72,8 +72,7 @@ class SimulatedDataGen():
         XYZ = self.dev(t)
         W = self.mb(XYZ, self.wl)
         S = self.vis(XYZ, W, self.wl)
-        G = self.gram(XYZ, W, self.wl)
-        __, V, __ = self.I_dp(S, G)
+        __, V, __ = self.I_dp(S, XYZ, W, self.wl)
         return (V,XYZ.data, W.data)
 
 

--- a/examples/real_data/lofar_bootes_ps.py
+++ b/examples/real_data/lofar_bootes_ps.py
@@ -75,10 +75,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     _ = I_mfs(D, V, XYZ.data, W.data, c_idx)
 I_std, I_lsq = I_mfs.as_image()
 
@@ -102,10 +101,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     _ = S_mfs(D, V, XYZ.data, W.data, cluster_idx=np.zeros(N_eig, dtype=int))
 _, S = S_mfs.as_image()
 

--- a/examples/real_data/lofar_bootes_ss.py
+++ b/examples/real_data/lofar_bootes_ss.py
@@ -72,10 +72,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     _ = I_mfs(D, V, XYZ.data, W.data, c_idx)
 I_std, I_lsq = I_mfs.as_image()
 
@@ -99,10 +98,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     _ = S_mfs(D, V, XYZ.data, W.data, cluster_idx=np.zeros(N_eig, dtype=int))
 _, S = S_mfs.as_image()
 

--- a/examples/simulation/lofar_4gaus_ps.py
+++ b/examples/simulation/lofar_4gaus_ps.py
@@ -84,10 +84,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     c_idx = [0,1,2,3]
     _ = I_mfs(D, V, XYZ.data, W.data, c_idx)
 I_std, I_lsq = I_mfs.as_image()
@@ -113,10 +112,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     _ = S_mfs(D, V, XYZ.data, W.data, cluster_idx=np.zeros(N_eig, dtype=int))
 _, S = S_mfs.as_image()
 

--- a/examples/simulation/lofar_4gaus_ss.py
+++ b/examples/simulation/lofar_4gaus_ss.py
@@ -114,10 +114,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     print(c_idx)
     c_idx = [0,1,2,3]
 

--- a/examples/simulation/lofar_bootes_nufft3.py
+++ b/examples/simulation/lofar_bootes_nufft3.py
@@ -60,7 +60,6 @@ obs_end = time[-1]
 # Imaging
 N_pix = 512
 eps = 1e-3
-w_term = True
 precision = 'single'
 
 t1 = tt.time()
@@ -82,40 +81,22 @@ N_eig, c_centroid = I_est.infer_parameters()
 # Imaging
 I_dp = bb_dp.IntensityFieldDataProcessorBlock(N_eig, c_centroid)
 IV_dp = bb_dp.VirtualVisibilitiesDataProcessingBlock(N_eig, filters=('lsq', 'sqrt'))
-UVW_baselines = []
-gram_corrected_visibilities = []
 
+nufft_imager = bb_im.NUFFT_IMFS_Block(wl=wl, grid_size=N_pix, FoV=FoV,
+                                      field_center=field_center, eps=eps,
+                                      n_trans=1, precision=precision)
 for t in ProgressBar(time[::time_slice]):
     XYZ = dev(t)
     UVW_baselines_t = dev.baselines(t, uvw=True, field_center=field_center)
-    UVW_baselines.append(UVW_baselines_t)
     W = mb(XYZ, wl)
     S = vis(XYZ, W, wl)
-    G = gram(XYZ, W, wl)
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     S_corrected = IV_dp(D, V, W, c_idx)
-    gram_corrected_visibilities.append(S_corrected)
+    nufft_imager.collect(UVW_baselines_t, S_corrected)
 
-UVW_baselines = np.stack(UVW_baselines, axis=0).reshape(-1, 3)
-gram_corrected_visibilities = np.stack(gram_corrected_visibilities, axis=-3).reshape(*S_corrected.shape[:2], -1)
-
-# fig = plt.figure()
-# # ax = Axes3D(fig)
-# # ax.scatter3D(UVW_baselines[::N_station, 0], UVW_baselines[::N_station, 1], UVW_baselines[::N_station, -1], s=.01)
-# # plt.xlabel('u')
-# # plt.ylabel('v')
-# # ax.set_zlabel('w')
-# plt.figure()
-# plt.scatter(UVW_baselines[:, 0], UVW_baselines[:, 1], s=0.01)
-# plt.xlabel('u')
-# plt.ylabel('v')
 
 # NUFFT Synthesis
-nufft_imager = bb_im.NUFFT_IMFS_Block(wl=wl, UVW=UVW_baselines.T, grid_size=N_pix, FoV=FoV,
-                                      field_center=field_center, eps=eps, w_term=w_term,
-                                      n_trans=np.prod(gram_corrected_visibilities.shape[:-1]), precision=precision)
-print(nufft_imager._synthesizer._inner_fft_sizes)
-lsq_image, sqrt_image = nufft_imager(gram_corrected_visibilities)
+lsq_image, sqrt_image = nufft_imager.get_statistic()
 
 ### Sensitivity Field =========================================================
 # Parameter Estimation
@@ -129,23 +110,20 @@ for t in ProgressBar(time[::200]):
 N_eig = S_est.infer_parameters()
 
 # Imaging
+nufft_imager = bb_im.NUFFT_IMFS_Block(wl=wl, grid_size=N_pix, FoV=FoV,
+                                      field_center=field_center, eps=eps,
+                                      n_trans=1, precision=precision)
 S_dp = bb_dp.SensitivityFieldDataProcessorBlock(N_eig)
 SV_dp = bb_dp.VirtualVisibilitiesDataProcessingBlock(N_eig, filters=('lsq',))
-sensitivity_coeffs = []
 for t in ProgressBar(time[::time_slice]):
     XYZ = dev(t)
+    UVW_baselines_t = dev.baselines(t, uvw=True, field_center=field_center)
     W = mb(XYZ, wl)
-    G = gram(XYZ, W, wl)
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     S_sensitivity = SV_dp(D, V, W, cluster_idx=np.zeros(N_eig, dtype=int))
-    sensitivity_coeffs.append(S_sensitivity)
+    nufft_imager.collect(UVW_baselines_t, S_sensitivity)
 
-sensitivity_coeffs = np.stack(sensitivity_coeffs, axis=0).reshape(-1)
-nufft_imager = bb_im.NUFFT_IMFS_Block(wl=wl, UVW=UVW_baselines.T, grid_size=N_pix, FoV=FoV,
-                                      field_center=field_center, eps=eps, w_term=w_term,
-                                      n_trans=1, precision=precision)
-print(nufft_imager._synthesizer._inner_fft_sizes)
-sensitivity_image = nufft_imager(sensitivity_coeffs)
+sensitivity_image = nufft_imager.get_statistic()[0]
 
 I_lsq_eq = s2image.Image(lsq_image / sensitivity_image, nufft_imager._synthesizer.xyz_grid)
 I_sqrt_eq = s2image.Image(sqrt_image / sensitivity_image, nufft_imager._synthesizer.xyz_grid)
@@ -178,3 +156,4 @@ for i in range(lsq_image.shape[0]):
 plt.suptitle(f'Bluebild Eigenmaps')
 
 plt.savefig('final.png')
+#  plt.show()

--- a/examples/simulation/lofar_bootes_nufft_small_fov.py
+++ b/examples/simulation/lofar_bootes_nufft_small_fov.py
@@ -140,9 +140,8 @@ for t in ProgressBar(time[0:25]):
     ICRS_baselines.append(baseline_rescaling * ICRS_baselines_t)
     W = mb(XYZ, wl)
     S = vis(XYZ, W, wl)
-    G = gram(XYZ, W, wl)
     W = W.data
-    D, V, _ = I_dp(S, G)
+    D, V, _ = I_dp(S, XYZ, W, wl)
     S_corrected = (W @ ((V @ np.diag(D)) @ V.transpose().conj())) @ W.transpose().conj()
     gram_corrected_visibilities.append(S_corrected)
 
@@ -202,9 +201,8 @@ sensitivity_coeffs = []
 for t in ProgressBar(time[0:25]):
     XYZ = dev(t)
     W = mb(XYZ, wl)
-    G = gram(XYZ, W, wl)
     W = W.data
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     S_sensitivity = (W @ ((V @ np.diag(D)) @ V.transpose().conj())) @ W.transpose().conj()
     sensitivity_coeffs.append(S_sensitivity)
 

--- a/examples/simulation/lofar_bootes_ps.py
+++ b/examples/simulation/lofar_bootes_ps.py
@@ -78,9 +78,8 @@ for t in ProgressBar(time[::1000]):
     XYZ = dev(t)
     W = mb(XYZ, wl)
     S = vis(XYZ, W, wl)
-    G = gram(XYZ, W, wl)
 
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     _ = I_mfs(D, V, XYZ.data, W.data, c_idx)
 I_std, I_lsq = I_mfs.as_image()
 
@@ -101,9 +100,8 @@ S_mfs = bb_fd.Fourier_IMFS_Block(wl, pix_colat, pix_lon, N_FS, T_kernel, R, 1, N
 for t in ProgressBar(time[::1000]):
     XYZ = dev(t)
     W = mb(XYZ, wl)
-    G = gram(XYZ, W, wl)
 
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     _ = S_mfs(D, V, XYZ.data, W.data, cluster_idx=np.zeros(N_eig, dtype=int))
 _, S = S_mfs.as_image()
 

--- a/examples/simulation/lofar_bootes_ps_small_fov.py
+++ b/examples/simulation/lofar_bootes_ps_small_fov.py
@@ -83,9 +83,8 @@ for t in ProgressBar(time[::25]):
     XYZ = dev(t)
     W = mb(XYZ, wl)
     S = vis(XYZ, W, wl)
-    G = gram(XYZ, W, wl)
 
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     _ = I_mfs(D, V, XYZ.data, W.data, c_idx)
 I_std, I_lsq = I_mfs.as_image()
 
@@ -106,9 +105,8 @@ S_mfs = bb_fd.Fourier_IMFS_Block(wl, pix_colat, pix_lon, N_FS, T_kernel, R, 1, N
 for t in ProgressBar(time[::25]):
     XYZ = dev(t)
     W = mb(XYZ, wl)
-    G = gram(XYZ, W, wl)
 
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     _ = S_mfs(D, V, XYZ.data, W.data, cluster_idx=np.zeros(N_eig, dtype=int))
 _, S = S_mfs.as_image()
 

--- a/examples/simulation/lofar_bootes_ss.py
+++ b/examples/simulation/lofar_bootes_ss.py
@@ -78,9 +78,8 @@ for t in ProgressBar(time[::50]):
     XYZ = dev(t)
     W = mb(XYZ, wl)
     S = vis(XYZ, W, wl)
-    G = gram(XYZ, W, wl)
 
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     _ = I_mfs(D, V, XYZ.data, W.data, c_idx)
 I_std, I_lsq = I_mfs.as_image()
 
@@ -101,9 +100,8 @@ S_mfs = bb_sd.Spatial_IMFS_Block(wl, px_grid, 1, N_bits)
 for t in ProgressBar(time[::50]):
     XYZ = dev(t)
     W = mb(XYZ, wl)
-    G = gram(XYZ, W, wl)
 
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     _ = S_mfs(D, V, XYZ.data, W.data, cluster_idx=np.zeros(N_eig, dtype=int))
 _, S = S_mfs.as_image()
 

--- a/examples/simulation/lofar_toothbrush_ps.py
+++ b/examples/simulation/lofar_toothbrush_ps.py
@@ -84,10 +84,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     _ = I_mfs(D, V, XYZ.data, W.data, c_idx)
 I_std, I_lsq = I_mfs.as_image()
 
@@ -111,10 +110,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     _ = S_mfs(D, V, XYZ.data, W.data, cluster_idx=np.zeros(N_eig, dtype=int))
 _, S = S_mfs.as_image()
 

--- a/examples/simulation/lofar_toothbrush_ss.py
+++ b/examples/simulation/lofar_toothbrush_ss.py
@@ -83,10 +83,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     _ = I_mfs(D, V, XYZ.data, W.data, c_idx)
 I_std, I_lsq = I_mfs.as_image()
 
@@ -110,10 +109,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     _ = S_mfs(D, V, XYZ.data, W.data, cluster_idx=np.zeros(N_eig, dtype=int))
 _, S = S_mfs.as_image()
 

--- a/jenkins/lofar_bootes_nufft_small_fov.py
+++ b/jenkins/lofar_bootes_nufft_small_fov.py
@@ -181,9 +181,8 @@ for t in time[::time_slice]:
     ICRS_baselines.append(baseline_rescaling * ICRS_baselines_t)
     W = mb(XYZ, wl)
     S = vis(XYZ, W, wl)
-    G = gram(XYZ, W, wl)
     W = W.data
-    D, V, _ = I_dp(S, G)
+    D, V, _ = I_dp(S, XYZ, W, wl)
     S_corrected = (W @ ((V @ np.diag(D)) @ V.transpose().conj())) @ W.transpose().conj()
     gram_corrected_visibilities.append(S_corrected)
 
@@ -250,9 +249,8 @@ sensitivity_coeffs = []
 for t in time[::time_slice]:
     XYZ = dev(t)
     W = mb(XYZ, wl)
-    G = gram(XYZ, W, wl)
     W = W.data
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     S_sensitivity = (W @ ((V @ np.diag(D)) @ V.transpose().conj())) @ W.transpose().conj()
     sensitivity_coeffs.append(S_sensitivity)
 

--- a/jenkins/lofar_bootes_ss.py
+++ b/jenkins/lofar_bootes_ss.py
@@ -124,8 +124,7 @@ for t in time[::time_slice]:
     XYZ = dev(t)
     W = mb(XYZ, wl)
     S = vis(XYZ, W, wl)
-    G = gram(XYZ, W, wl)
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     _ = I_mfs(D, V, XYZ.data, W.data, c_idx)
 
 I_std, I_lsq = I_mfs.as_image()
@@ -154,8 +153,7 @@ S_mfs = bb_sd.Spatial_IMFS_Block(wl, px_grid, 1, N_bits)
 for t in time[::time_slice]:
     XYZ = dev(t)
     W = mb(XYZ, wl)
-    G = gram(XYZ, W, wl)
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     _ = S_mfs(D, V, XYZ.data, W.data, cluster_idx=np.zeros(N_eig, dtype=int))
 _, S = S_mfs.as_image()
 

--- a/pypeline/phased_array/bluebild/data_processor.py
+++ b/pypeline/phased_array/bluebild/data_processor.py
@@ -11,12 +11,12 @@ Data processors.
 import imot_tools.math.linalg as pylinalg
 import imot_tools.util.argcheck as chk
 import numpy as np
-import nvtx
 
 import pypeline.core as core
 import pypeline.phased_array.data_gen.statistics as vis
 import pypeline.phased_array.bluebild.gram as gram
-import pypeline.phased_array.beamforming as bb_beam
+import pypeline.phased_array.beamforming as beamforming
+import pypeline.phased_array.instrument as instrument
 import typing as typ
 import scipy.sparse as sparse
 
@@ -76,8 +76,15 @@ class IntensityFieldDataProcessorBlock(DataProcessorBlock):
         self._N_eig = N_eig
         self._cluster_centroids = np.array(cluster_centroids, copy=False)
 
-    @chk.check(dict(S=chk.is_instance(vis.VisibilityMatrix), G=chk.is_instance(gram.GramMatrix)))
-    def __call__(self, S, G):
+    @chk.check(
+        dict(
+            S=chk.is_instance(vis.VisibilityMatrix),
+            XYZ=chk.is_instance(instrument.InstrumentGeometry),
+            W=chk.is_instance(beamforming.BeamWeights),
+            wl=chk.is_real,
+        )
+    )
+    def __call__(self, S, XYZ, W, wl, ctx=None):
         """
         fPCA decomposition and data formatting for
         :py:class:`~pypeline.phased_array.bluebild.field_synthesizer.FieldSynthesizerBlock` objects.
@@ -88,8 +95,14 @@ class IntensityFieldDataProcessorBlock(DataProcessorBlock):
         ----------
         S : :py:class:`~pypeline.phased_array.data_gen.statistics.VisibilityMatrix`
             (N_beam, N_beam) visibility matrix.
-        G : :py:class:`~pypeline.phased_array.bluebild.gram.GramMatrix`
-            (N_beam, N_beam) gram matrix.
+        XYZ : :py:class:`~pypeline.phased_array.instrument.InstrumentGeometry`
+            (N_antenna, 3) Cartesian antenna coordinates in any reference frame.
+        W : :py:class:`~pypeline.phased_array.beamforming.BeamWeights`
+            (N_antenna, N_beam) synthesis beamweights.
+        wl : float
+            Wavelength [m] at which to compute the Gram.
+        ctx: :py:class:`~bluebild.Context`
+            Bluebuild context. If provided, will use bluebild module for computation.
 
         Returns
         -------
@@ -148,30 +161,41 @@ class IntensityFieldDataProcessorBlock(DataProcessorBlock):
            >>> cluster_idx  # useful for aggregation stage.
            array([0, 0])
         """
-        if not S.is_consistent_with(G, axes=[0, 0]):
-            raise ValueError("Parameters[S, G] are inconsistent.")
+
+
+        N_beam = len(S.data)
 
         # Remove broken BEAM_IDs
-        N_beam = len(G.data)
         broken_row_id = np.flatnonzero(np.isclose(np.sum(S.data, axis=0), np.sum(S.data, axis=1)))
-        working_row_id = list(set(np.arange(N_beam)) - set(broken_row_id))
-        idx = np.ix_(working_row_id, working_row_id)
-        S, G = S.data[idx], G.data[idx]
+        if broken_row_id.size:
+            working_row_id = list(set(np.arange(N_beam)) - set(broken_row_id))
+            idx = np.ix_(working_row_id, working_row_id)
+            S, W = S.data[idx], W.data[:, working_row_id]
+        else:
+            S, W = S.data, W.data
 
-        # Functional PCA
-        with nvtx.annotate("fPCA", color="pink"):
+        if ctx is not None:
+            D, V, cluster_idx = ctx.intensity_field_data(self._N_eig, np.array(XYZ.data, order='F'), np.array(W.data, order='F'),
+                    wl, S, self._cluster_centroids)
+        else:
+            G = gram.GramBlock().compute(XYZ.data, W, wl)
+
+            # Functional PCA
             if not np.allclose(S, 0):
                 D, V = pylinalg.eigh(S, G, tau=1, N=self._N_eig)
             else:  # S is broken beyond use
                 D, V = np.zeros(self._N_eig), 0
 
-        # Add broken BEAM_IDs
-        V_aligned = np.zeros((N_beam, self._N_eig), dtype=np.complex)
-        V_aligned[working_row_id] = V
+            # Determine energy-level clustering
+            cluster_dist = np.absolute(D.reshape(-1, 1) - self._cluster_centroids.reshape(1, -1))
+            cluster_idx = np.argmin(cluster_dist, axis=1)
 
-        # Determine energy-level clustering
-        cluster_dist = np.absolute(D.reshape(-1, 1) - self._cluster_centroids.reshape(1, -1))
-        cluster_idx = np.argmin(cluster_dist, axis=1)
+        # Add broken BEAM_IDs
+        if broken_row_id.size:
+            V_aligned = np.zeros((N_beam, self._N_eig), dtype=np.complex)
+            V_aligned[working_row_id] = V
+        else:
+            V_aligned = V
 
         return D, V_aligned, cluster_idx
 
@@ -202,16 +226,28 @@ class SensitivityFieldDataProcessorBlock(DataProcessorBlock):
         super().__init__()
         self._N_eig = N_eig
 
-    @chk.check("G", chk.is_instance(gram.GramMatrix))
-    def __call__(self, G):
+    @chk.check(
+        dict(
+            XYZ=chk.is_instance(instrument.InstrumentGeometry),
+            W=chk.is_instance(beamforming.BeamWeights),
+            wl=chk.is_real,
+        )
+    )
+    def __call__(self, XYZ, W, wl, ctx=None):
         """
         fPCA decomposition and data formatting for
         :py:class:`~pypeline.phased_array.bluebild.field_synthesizer.FieldSynthesizerBlock` objects.
 
         Parameters
         ----------
-        G : :py:class:`~pypeline.phased_array.bluebild.gram.GramMatrix`
-            (N_beam, N_beam) gram matrix.
+        XYZ : :py:class:`~pypeline.phased_array.instrument.InstrumentGeometry`
+            (N_antenna, 3) Cartesian antenna coordinates in any reference frame.
+        W : :py:class:`~pypeline.phased_array.beamforming.BeamWeights`
+            (N_antenna, N_beam) synthesis beamweights.
+        wl : float
+            Wavelength [m] at which to compute the Gram.
+        ctx: :py:class:`~bluebild.Context`
+            Bluebuild context. If provided, will use bluebild module for computation.
 
         Returns
         -------
@@ -258,11 +294,15 @@ class SensitivityFieldDataProcessorBlock(DataProcessorBlock):
            >>> np.around(D, 6)
            array([9.2e-05, 9.4e-05])
         """
-        N_beam = len(G.data)
-        D, V = pylinalg.eigh(G.data, np.eye(N_beam), tau=1, N=self._N_eig)
-        Dg = 1 / (D ** 2)
 
-        return Dg, V
+        if ctx is not None:
+            return ctx.sensitivity_field_data(self._N_eig, np.array(XYZ.data, order='F'), np.array(W.data, order='F'), wl)
+        else:
+            G = gram.GramBlock()(XYZ, W, wl)
+            N_beam = len(G.data)
+            D, V = pylinalg.eigh(G.data, np.eye(N_beam), tau=1, N=self._N_eig)
+            Dg = 1 / (D ** 2)
+            return Dg, V
 
 
 class VirtualVisibilitiesDataProcessingBlock(DataProcessorBlock):
@@ -289,7 +329,7 @@ class VirtualVisibilitiesDataProcessingBlock(DataProcessorBlock):
         self.filters = filters
         self._N_eig = N_eig
 
-    def __call__(self, D: np.ndarray, V: np.ndarray, W: typ.Optional[bb_beam.MatchedBeamformerBlock] = None,
+    def __call__(self, D: np.ndarray, V: np.ndarray, W: typ.Optional[beamforming.MatchedBeamformerBlock] = None,
                  cluster_idx: typ.Optional[np.ndarray] = None) -> np.ndarray:
         r"""
         Filter the fPCA eigenlevels and transform them into virtual visibilities. If a beamforming matrix is provided the

--- a/pypeline/phased_array/bluebild/field_synthesizer/fourier_domain.py
+++ b/pypeline/phased_array/bluebild/field_synthesizer/fourier_domain.py
@@ -27,6 +27,11 @@ import finufft
 import astropy.coordinates as aspy
 
 
+try:
+    import bluebild
+except ImportError:
+    pass
+
 class FourierFieldSynthesizerBlock(synth.FieldSynthesizerBlock):
     """
     Field synthesizer based on PeriodicSynthesis.
@@ -480,16 +485,14 @@ class NUFFTFieldSynthesizerBlock(synth.FieldSynthesizerBlock):
     _precision_mappings = dict(single=dict(complex=np.complex64, real=np.float32, dtype='float32'),
                                double=dict(complex=np.complex128, real=np.float64, dtype='float64'))
 
-    def __init__(self, wl: float, UVW: np.ndarray, grid_size: int, FoV: float, field_center: aspy.SkyCoord,
-                 eps: float = 1e-6, w_term: bool = True, n_trans: int = 1, precision: str = 'double'):
+    def __init__(self, wl: float, grid_size: int, FoV: float, field_center: aspy.SkyCoord,
+                 eps: float = 1e-3, n_trans: int = 1, precision: str = 'double', bluebild_ctx = None):
         r"""
 
         Parameters
         ----------
         wl: float
             Observation wavelength.
-        UVW: np.ndarray
-            (3, N_uvw) UVW coordinates expressed in the local UVW frame.
         grid_size: int
             Size of the output imaging grid across each dimension.
         FoV: float
@@ -498,19 +501,20 @@ class NUFFTFieldSynthesizerBlock(synth.FieldSynthesizerBlock):
             Center of the field of view for defining the local UVW frame.
         eps: float
             Relative tolerance of the NUFFT.
-        w_term: bool
-            Neglects the ``w_term`` (do not use for large FoV!).
         n_trans: int
             Number of simultaneous NUFFT transforms.
         precision: str
             Whether to use ``'single'`` or ``'double'`` precision.
+        bluebild_ctx: :py:class:`~bluebild.Context`
+            Bluebuild context. If provided, will use bluebild module provided nufft.
         """
+        self._wl = wl
+        self._eps = eps
         self._precision = precision
-        UVW = np.array(UVW, copy=False)
-        self._UVW = (2 * np.pi * UVW.reshape(3, -1) / wl).astype(self._precision_mappings[self._precision]['real'])
         self._FoV = FoV
         self._field_center = field_center
-        if(w_term and type(grid_size) != int):
+        self._ctx = bluebild_ctx
+        if type(grid_size) != int:
             uvw_frame = frame.uvw_basis(self._field_center)
             self.xyz_grid = grid_size       # pass a grid instead of calculating it
             self.lmn_grid = np.tensordot(np.linalg.inv(uvw_frame), self.xyz_grid, axes=1)
@@ -520,29 +524,9 @@ class NUFFTFieldSynthesizerBlock(synth.FieldSynthesizerBlock):
 
         self._lmn_grid = self.lmn_grid.reshape(3, -1).astype(self._precision_mappings[self._precision]['real'])
         self._n_trans = n_trans
-        if w_term:
-            grid_center = self._lmn_grid.mean(axis=-1)
-            self._lmn_grid -= grid_center[:, None]
-            self._prephasing = np.exp(1j * np.sum(grid_center[:, None] * self._UVW, axis=0)).squeeze().astype(
-                self._precision_mappings[self._precision]['complex'])
-            self._plan = finufft.Plan(nufft_type=3, n_modes_or_dim=3, eps=eps, isign=1, n_trans=n_trans,
-                                      dtype=self._precision_mappings[self._precision]['dtype'])
-            self._plan.setpts(x=self._UVW[0], y=self._UVW[1], z=self._UVW[-1],
-                              s=self._lmn_grid[0], t=self._lmn_grid[1], u=self._lmn_grid[-1])
-            self._inner_fft_sizes = np.floor(4 * np.linalg.norm(self._lmn_grid, ord=np.infty, axis=-1) * \
-                                             np.linalg.norm(self._UVW, ord=np.infty, axis=-1) / np.pi +
-                                             np.log(1 / eps) + 1)
-        else:
-            warnings.warn('Setting the parameter w_term to False can result in a loss of accuracy for large FoVs!',
-                          UserWarning)
-            scaling = (2 * np.sin(self._FoV / 2) / self._grid_size).astype(
-                self._precision_mappings[self._precision]['real'])
-            self._prephasing = np.exp(1j * self._UVW[-1]).squeeze().astype(
-                self._precision_mappings[self._precision]['complex'])
-            self._plan = finufft.Plan(nufft_type=1, n_modes_or_dim=(self._grid_size, self._grid_size),
-                                      eps=eps, isign=1, n_trans=n_trans,
-                                      dtype=self._precision_mappings[self._precision]['dtype'])
-            self._plan.setpts(x=scaling * self._UVW[1], y=scaling * self._UVW[0])
+        self._grid_center = self._lmn_grid.mean(axis=-1)
+        self._lmn_grid -= self._grid_center[:, None]
+
         super(NUFFTFieldSynthesizerBlock, self).__init__()
 
     def _make_grids(self) -> typ.Tuple[np.ndarray, np.ndarray]:
@@ -563,12 +547,14 @@ class NUFFTFieldSynthesizerBlock(synth.FieldSynthesizerBlock):
         xyz_grid = np.tensordot(uvw_frame, lmn_grid, axes=1)
         return lmn_grid, xyz_grid
 
-    def __call__(self, V: np.ndarray) -> np.ndarray:
+    def __call__(self, UVW: np.ndarray, V: np.ndarray) -> np.ndarray:
         r"""
         Synthesize a set of virtual visibilities.
 
         Parameters
         ----------
+        UVW: np.ndarray
+            (3, N_uvw) UVW coordinates expressed in the local UVW frame.
         V: np.ndarray
             (M, N_uvw) stack of virtual visibilities to synthesize. If the ``n_trans`` parameter of the NUFFT plan is
              different from zero, then one must have ``M==n_trans``. In which case, the ``M`` NUFFTs are computed in parallel
@@ -578,21 +564,36 @@ class NUFFTFieldSynthesizerBlock(synth.FieldSynthesizerBlock):
         field: np.ndarray
             (M, N_pix) field values.
         """
+        UVW = np.array(UVW, copy=False)
+        UVW = (2 * np.pi * UVW.reshape(3, -1) / self._wl).astype(self._precision_mappings[self._precision]['real'])
         V = np.array(V, copy=False).squeeze().astype(self._precision_mappings[self._precision]['complex'])
+
+        prephasing = np.exp(1j * np.sum(self._grid_center[:, None] * UVW, axis=0)).squeeze().astype(
+            self._precision_mappings[self._precision]['complex'])
+
+        if self._ctx is not None:
+            plan = bluebild.Nufft3d3(1, self._eps, self._n_trans, UVW[0], UVW[1], UVW[2],
+                    self._lmn_grid[0], self._lmn_grid[1], self._lmn_grid[-1], self._ctx)
+        else:
+            plan = finufft.Plan(nufft_type=3, n_modes_or_dim=3, eps=self._eps, isign=1, n_trans=self._n_trans,
+                                dtype=self._precision_mappings[self._precision]['dtype'])
+            plan.setpts(x=UVW[0], y=UVW[1], z=UVW[-1],
+                        s=self._lmn_grid[0], t=self._lmn_grid[1], u=self._lmn_grid[-1])
+
         if V.ndim > 1:
-            V = V.reshape(-1, self._UVW.shape[-1])
-            self._prephasing = self._prephasing[None, :]
-            V *= self._prephasing
+            V = V.reshape(-1, UVW.shape[-1])
+            prephasing = prephasing[None, :]
+            V *= prephasing
             if self._n_trans == 1:  # NUFFT are evaluated sequentially
                 out = []
                 for n in range(V.shape[0]):
-                    out.append(np.real(self._plan.execute(V[n])))
+                    out.append(np.real(plan.execute(V[n])))
                 out = np.stack(out, axis=0)
             else:
-                out = np.real(self._plan.execute(
+                out = np.real(plan.execute(
                     V))  # NUFFT are evaluated in parallel (not clear if multi-threaded or multi-processed?)
         else:
-            out = np.real(self._plan.execute(V * self._prephasing))
+            out = np.real(plan.execute(V * prephasing))
         return out
 
     def synthesize(self, V: np.ndarray) -> np.ndarray:

--- a/pypeline/phased_array/bluebild/field_synthesizer/fourier_domain.py
+++ b/pypeline/phased_array/bluebild/field_synthesizer/fourier_domain.py
@@ -486,7 +486,7 @@ class NUFFTFieldSynthesizerBlock(synth.FieldSynthesizerBlock):
                                double=dict(complex=np.complex128, real=np.float64, dtype='float64'))
 
     def __init__(self, wl: float, grid_size: int, FoV: float, field_center: aspy.SkyCoord,
-                 eps: float = 1e-3, n_trans: int = 1, precision: str = 'double', bluebild_ctx = None):
+                 eps: float = 1e-3, n_trans: int = 1, precision: str = 'double', ctx = None):
         r"""
 
         Parameters
@@ -505,15 +505,15 @@ class NUFFTFieldSynthesizerBlock(synth.FieldSynthesizerBlock):
             Number of simultaneous NUFFT transforms.
         precision: str
             Whether to use ``'single'`` or ``'double'`` precision.
-        bluebild_ctx: :py:class:`~bluebild.Context`
-            Bluebuild context. If provided, will use bluebild module provided nufft.
+        ctx: :py:class:`~bluebild.Context`
+            Bluebuild context. If provided, the bluebild library will be used for computation.
         """
         self._wl = wl
         self._eps = eps
         self._precision = precision
         self._FoV = FoV
         self._field_center = field_center
-        self._ctx = bluebild_ctx
+        self._ctx = ctx
         if type(grid_size) != int:
             uvw_frame = frame.uvw_basis(self._field_center)
             self.xyz_grid = grid_size       # pass a grid instead of calculating it

--- a/pypeline/phased_array/bluebild/gram.py
+++ b/pypeline/phased_array/bluebild/gram.py
@@ -88,7 +88,7 @@ class GramBlock(core.Block):
             wl=chk.is_real,
         )
     )
-    def __call__(self, XYZ, W, wl):
+    def __call__(self, XYZ, W, wl, ctx=None):
         """
         Compute Gram matrix.
 
@@ -100,6 +100,8 @@ class GramBlock(core.Block):
             (N_antenna, N_beam) synthesis beamweights.
         wl : float
             Wavelength [m] at which to compute the Gram.
+        ctx: :py:class:`~bluebild.Context`
+            Bluebuild context. If provided, will use bluebild module for computation.
 
         Returns
         -------
@@ -144,12 +146,38 @@ class GramBlock(core.Block):
         if not XYZ.is_consistent_with(W, axes=[0, 0]):
             raise ValueError("Parameters[XYZ, W] are inconsistent.")
 
-        N_antenna = XYZ.shape[0]
-        baseline = linalg.norm(
-            XYZ.data.reshape(N_antenna, 1, 3) - XYZ.data.reshape(1, N_antenna, 3), axis=-1
-        )
+        return GramMatrix(data=self.compute(XYZ.data, W.data, wl, ctx), beam_idx=W.index[1])
 
-        G_1 = (4 * np.pi) * np.sinc((2 / wl) * baseline)
-        G_2 = W.data.conj().T @ G_1 @ W.data
 
-        return GramMatrix(data=G_2, beam_idx=W.index[1])
+    def compute(self, XYZ, W, wl, ctx=None):
+        """
+        Compute Gram matrix as numpy array.
+
+        Parameters
+        ----------
+        XYZ : :py:class:`~pypeline.phased_array.instrument.InstrumentGeometry`
+            (N_antenna, 3) Cartesian antenna coordinates in any reference frame.
+        W : :py:class:`~pypeline.phased_array.beamforming.BeamWeights`
+            (N_antenna, N_beam) synthesis beamweights.
+        wl : float
+            Wavelength [m] at which to compute the Gram.
+        ctx: :py:class:`~bluebild.Context`
+            Bluebuild context. If provided, will use bluebild module for computation.
+
+        Returns
+        -------
+        :py:class:`~numpy.ndarray`
+            (N_beam, N_beam) Gram matrix.
+        """
+        if ctx is not None:
+            return ctx.gram_matrix(np.array(XYZ.data, order='F'), np.array(W.data, order='F'), wl)
+        else:
+            N_antenna = XYZ.shape[0]
+            baseline = linalg.norm(
+                XYZ.reshape(N_antenna, 1, 3) - XYZ.reshape(1, N_antenna, 3), axis=-1
+            )
+
+            G_1 = (4 * np.pi) * np.sinc((2 / wl) * baseline)
+            G_2 = W.conj().T @ G_1 @ W
+            return G_2
+

--- a/pypeline/phased_array/bluebild/gram.py
+++ b/pypeline/phased_array/bluebild/gram.py
@@ -75,11 +75,16 @@ class GramBlock(core.Block):
     Compute Gram matrices.
     """
 
-    def __init__(self):
+    def __init__(self, ctx=None):
         """
+        Parameters
+        ----------
+        ctx: :py:class:`~bluebild.Context`
+            Bluebuild context. If provided, will use bluebild module for computation.
 
         """
         super().__init__()
+        self._ctx=ctx
 
     @chk.check(
         dict(
@@ -88,7 +93,7 @@ class GramBlock(core.Block):
             wl=chk.is_real,
         )
     )
-    def __call__(self, XYZ, W, wl, ctx=None):
+    def __call__(self, XYZ, W, wl):
         """
         Compute Gram matrix.
 
@@ -100,8 +105,6 @@ class GramBlock(core.Block):
             (N_antenna, N_beam) synthesis beamweights.
         wl : float
             Wavelength [m] at which to compute the Gram.
-        ctx: :py:class:`~bluebild.Context`
-            Bluebuild context. If provided, will use bluebild module for computation.
 
         Returns
         -------
@@ -146,10 +149,10 @@ class GramBlock(core.Block):
         if not XYZ.is_consistent_with(W, axes=[0, 0]):
             raise ValueError("Parameters[XYZ, W] are inconsistent.")
 
-        return GramMatrix(data=self.compute(XYZ.data, W.data, wl, ctx), beam_idx=W.index[1])
+        return GramMatrix(data=self.compute(XYZ.data, W.data, wl), beam_idx=W.index[1])
 
 
-    def compute(self, XYZ, W, wl, ctx=None):
+    def compute(self, XYZ, W, wl):
         """
         Compute Gram matrix as numpy array.
 
@@ -161,16 +164,14 @@ class GramBlock(core.Block):
             (N_antenna, N_beam) synthesis beamweights.
         wl : float
             Wavelength [m] at which to compute the Gram.
-        ctx: :py:class:`~bluebild.Context`
-            Bluebuild context. If provided, will use bluebild module for computation.
 
         Returns
         -------
         :py:class:`~numpy.ndarray`
             (N_beam, N_beam) Gram matrix.
         """
-        if ctx is not None:
-            return ctx.gram_matrix(np.array(XYZ.data, order='F'), np.array(W.data, order='F'), wl)
+        if self._ctx is not None:
+            return self._ctx.gram_matrix(np.array(XYZ.data, order='F'), np.array(W.data, order='F'), wl)
         else:
             N_antenna = XYZ.shape[0]
             baseline = linalg.norm(

--- a/pypeline/phased_array/bluebild/imager/fourier_domain.py
+++ b/pypeline/phased_array/bluebild/imager/fourier_domain.py
@@ -271,16 +271,15 @@ class NUFFT_IMFS_Block(bim.IntegratingMultiFieldSynthesizerBlock):
     Multi-field synthesizer based on the NUFFT synthesizer.
     """
 
-    def __init__(self, wl: float, UVW: np.ndarray, grid_size: int, FoV: float, field_center: aspy.SkyCoord,
-                 eps: float = 1e-6, w_term: bool = True, n_trans: int = 1, precision: str = 'double'):
+    def __init__(self, wl: float, grid_size: int, FoV: float, field_center: aspy.SkyCoord,
+                 eps: float = 1e-3, n_trans: int = 1, precision: str = 'double', max_collect_bytes = 2 * 10**9,
+                 bluebild_ctx = None):
         r"""
 
         Parameters
         ----------
         wl: float
             Observation wavelength.
-        UVW: np.ndarray
-            (3, N_uvw) UVW coordinates expressed in the local UVW frame.
         grid_size: int
             Size of the output imaging grid across each dimension.
         FoV: float
@@ -289,36 +288,43 @@ class NUFFT_IMFS_Block(bim.IntegratingMultiFieldSynthesizerBlock):
             Center of the field of view for defining the local UVW frame.
         eps: float
             Relative tolerance of the NUFFT.
-        w_term: bool
-            Neglects the ``w_term`` (do not use for large FoV!).
         n_trans: int
             Number of simultaneous NUFFT transforms.
         precision: str
             Whether to use ``'single'`` or ``'double'`` precision.
+        bluebild_ctx: :py:class:`~bluebild.Context`
+            Bluebuild context. If provided, will use bluebild module provided nufft.
         """
-        self._synthesizer = psd.NUFFTFieldSynthesizerBlock(wl=wl, UVW=UVW, grid_size=grid_size, FoV=FoV,
+        self._synthesizer = psd.NUFFTFieldSynthesizerBlock(wl=wl, grid_size=grid_size, FoV=FoV,
                                                            field_center=field_center, eps=eps,
-                                                           w_term=w_term, n_trans=n_trans, precision=precision)
+                                                           n_trans=n_trans, precision=precision,
+                                                           bluebild_ctx=bluebild_ctx)
+        self._V_collection = []
+        self._UVW_collection = []
+        self._nbytes = 0
+        self._max_colllect_bytes = max_collect_bytes
         super(NUFFT_IMFS_Block, self).__init__()
 
-    def __call__(self, V: np.ndarray) -> np.ndarray:
+    def __call__(self, UVW: np.ndarray, V: np.ndarray) -> np.ndarray:
         r"""
         Image a set of (virtual) visibilities.
 
         Parameters
         ----------
+        UVW: np.ndarray
+            (3, N_uvw) UVW coordinates expressed in the local UVW frame.
         V: np.ndarray
             (M, N_uvw) stack of virtual visibilities to synthesize. If the ``n_trans`` parameter of the NUFFT plan is
             different from zero, then one must have ``M==n_trans``. In which case, the ``M`` NUFFTs are computed in parallel
             using OpenMP multi-threading. Otherwise, the ``M`` NUFFTs are computed sequentially.
-        Returns
-        -------
-        field: np.ndarray
-            (M, N_pix) field statistics. Output is also stored in private attribute ``self._statistics``.
         """
-        V_shape = V.shape[:-1]
-        self._statistics = self._synthesizer(V).reshape(V_shape + self._synthesizer.xyz_grid.shape[1:])
-        return self._statistics
+
+        self._nbytes += UVW.nbytes + V.nbytes
+        self._V_collection.append(V)
+        self._UVW_collection.append(UVW)
+
+        if self._nbytes > self._max_colllect_bytes:
+            self._compute()
 
     def as_image(self) -> list:
         r"""
@@ -329,7 +335,25 @@ class NUFFT_IMFS_Block(bim.IntegratingMultiFieldSynthesizerBlock):
         out : list[:py:class:`~imot_tools.io.s2image.Image`]
             List of energy-level image cubes with size (N_level, N_height, N_width).
         """
+
+        self._compute()
+
         out = []
         for stat in self._statistics:
             out.append(image.Image(stat, self._synthesizer.xyz_grid))
         return out
+
+    def get_statistic(self):
+        self._compute()
+        return self._statistics
+
+    def _compute(self):
+        if len(self._V_collection):
+            UVW = np.stack(self._UVW_collection, axis=0).reshape(-1, 3).T
+            V = np.stack(self._V_collection, axis=-3).reshape(*self._V_collection[-1].shape[:2], -1)
+            V_shape = V.shape[:-1]
+            stat = self._synthesizer(UVW, V).reshape(V_shape + self._synthesizer.xyz_grid.shape[1:])
+            self._update(stat)
+            self._V_collection = []
+            self._UVW_collection = []
+            self._nbytes = 0

--- a/pypeline/phased_array/bluebild/imager/fourier_domain.py
+++ b/pypeline/phased_array/bluebild/imager/fourier_domain.py
@@ -273,7 +273,7 @@ class NUFFT_IMFS_Block(bim.IntegratingMultiFieldSynthesizerBlock):
 
     def __init__(self, wl: float, grid_size: int, FoV: float, field_center: aspy.SkyCoord,
                  eps: float = 1e-3, n_trans: int = 1, precision: str = 'double', max_collect_bytes = 2 * 10**9,
-                 bluebild_ctx = None):
+                 ctx = None):
         r"""
 
         Parameters
@@ -292,20 +292,20 @@ class NUFFT_IMFS_Block(bim.IntegratingMultiFieldSynthesizerBlock):
             Number of simultaneous NUFFT transforms.
         precision: str
             Whether to use ``'single'`` or ``'double'`` precision.
-        bluebild_ctx: :py:class:`~bluebild.Context`
-            Bluebuild context. If provided, will use bluebild module provided nufft.
+        ctx: :py:class:`~bluebild.Context`
+            Bluebuild context. If provided, the bluebild library will be used for computation.
         """
         self._synthesizer = psd.NUFFTFieldSynthesizerBlock(wl=wl, grid_size=grid_size, FoV=FoV,
                                                            field_center=field_center, eps=eps,
                                                            n_trans=n_trans, precision=precision,
-                                                           bluebild_ctx=bluebild_ctx)
+                                                           ctx=ctx)
         self._V_collection = []
         self._UVW_collection = []
         self._nbytes = 0
         self._max_colllect_bytes = max_collect_bytes
         super(NUFFT_IMFS_Block, self).__init__()
 
-    def __call__(self, UVW: np.ndarray, V: np.ndarray) -> np.ndarray:
+    def collect(self, UVW: np.ndarray, V: np.ndarray) -> np.ndarray:
         r"""
         Image a set of (virtual) visibilities.
 

--- a/python/data_gen_utils.py
+++ b/python/data_gen_utils.py
@@ -142,7 +142,7 @@ class SimulatedDataGen():
         W = self.mb(XYZ, self.wl)
         S = self.vis(XYZ, W, self.wl)
         G = self.gram(XYZ, W, self.wl)
-        #D, V, __ = self.I_dp(S, G)
+        #D, V, __ = self.I_dp(S, XYZ, W, self.wl)
         return (V,XYZ.data, W.data, s, G)
 #################################################################################
 class RealDataGen():
@@ -207,9 +207,8 @@ class RealDataGen():
 
         XYZ = self.ms.instrument(t)
         W = self.ms.beamformer(XYZ, self.wl)
-        G = self.gram(XYZ, W, self.wl)
         S, _ = measurement_set.filter_data(S, W)
-        D, V, c_idx = self.I_dp(S, G)
+        D, V, c_idx = self.I_dp(S, XYZ, W, self.wl)
 
         return (V,XYZ.data, W.data,D)
     def getInputs(self, i):
@@ -218,9 +217,8 @@ class RealDataGen():
         wl = constants.speed_of_light / f.to_value(u.Hz) #self.wl
         XYZ = self.ms.instrument(t)
         W = self.ms.beamformer(XYZ, wl)
-        G = self.gram(XYZ, W, wl)
         S, _ = measurement_set.filter_data(S, W)
-        D, V, c_idx = self.I_dp(S, G)
-        Ds, Vs = self.S_dp(G)
+        D, V, c_idx = self.I_dp(S, XYZ, W, wl)
+        Ds, Vs = self.S_dp(XYZ, W, wl)
 
         return (V, Vs, XYZ.data, W.data,D, Ds)

--- a/python/lofar_bootes_ps.py
+++ b/python/lofar_bootes_ps.py
@@ -82,10 +82,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     _ = I_mfs(D, V, XYZ.data, W.data, c_idx)
     c += 1
     if c > 20: break
@@ -112,10 +111,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     _ = S_mfs(D, V, XYZ.data, W.data, cluster_idx=np.zeros(N_eig, dtype=int))
     c += 1
     if c > 20: break

--- a/python/lofar_bootes_ss.py
+++ b/python/lofar_bootes_ss.py
@@ -78,10 +78,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V, c_idx = I_dp(S, G)
+    D, V, c_idx = I_dp(S, XYZ, W, wl)
     _ = I_mfs(D, V, XYZ.data, W.data, c_idx)
     c += 1
     if c > 10: break
@@ -108,10 +107,9 @@ for t, f, S in ProgressBar(
     wl = constants.speed_of_light / f.to_value(u.Hz)
     XYZ = ms.instrument(t)
     W = ms.beamformer(XYZ, wl)
-    G = gram(XYZ, W, wl)
     S, W = measurement_set.filter_data(S, W)
 
-    D, V = S_dp(G)
+    D, V = S_dp(XYZ, W, wl)
     _ = S_mfs(D, V, XYZ.data, W.data, cluster_idx=np.zeros(N_eig, dtype=int))
     c += 1
     if c > 10: break


### PR DESCRIPTION
Two main changes:

- The NUFFT imager `NUFFT_IMFS_Block` now collects the input and computes the NUFFT if the memory size exceeds a given threshold. In addition, optional computation using the C++ library interface to fiNUFFT and cufiNUFFT is now possible.
- The data processing classes `IntensityFieldDataProcessorBlock` and `SensitivityFieldDataProcessorBlock` now include the calculation of the gram matrix, to allow for optional dispatch to the C++ library.